### PR TITLE
Add support for @bem/cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@
 
 ## Usage
 ```js
-var entity = {
-    block: 'b1',
-    elem: 'e1',
-    modName: 'm1',
-    modVal: 'v1'
-};
+var BemCell = require('@bem/cell'),
+    BemEntityName = require('@bem/entity-name');
 
-var tech = 'js';
+var atom = new BemCell(
+    {
+        entity: new BemEntityName({
+            block: 'b1',
+            elem: 'e1',
+            mod: {name: 'm1', val: 'v1'}
+        }),
+        tech: 'js'
+    }
+);
 
 var options = {
     naming: {
@@ -25,7 +30,9 @@ var options = {
     }
 }; // this is default value
 
-require('bem-fs-scheme')('nested').path(entity, tech, options); // b1/__e1/_m1/b1__e1_m1_v1.js
+var bemFs = require('bem-fs-scheme')('nested')
+
+bemFs.path(atom, options); // b1/__e1/_m1/b1__e1_m1_v1.js
 ```
 
 License

--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -20,6 +20,7 @@ module.exports = {
 
         var naming = bemNaming(options.naming);
 
-        return path.join(layer, naming.stringify(entity) + '.' + _tech);
+        return path.join(layer,
+            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
     }
 };

--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -1,26 +1,19 @@
 var path = require('path'),
-    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
-    path: function(entity, tech, options) {
+    path: function(cell, options) {
         options || (options = {});
 
         var layer = '';
-        var _tech = tech;
+        var tech = cell.tech;
+        var entity = cell.entity;
 
-        if (BemCell.isBemCell(entity)) {
-            entity.layer && (layer = entity.layer);
-            if (typeof tech === 'object') {
-                options = tech;
-            }
-            _tech = entity.tech;
-            entity = entity.entity;
-        }
+        cell.layer && (layer = cell.layer);
 
         var naming = bemNaming(options.naming);
 
         return path.join(layer,
-            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
+            naming.stringify(entity) + (tech ? '.' + tech : ''));
     }
 };

--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -1,10 +1,25 @@
-var bemNaming = require('bem-naming');
+var path = require('path'),
+    BemCell = require('@bem/cell'),
+    bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(entity, tech, options) {
         options || (options = {});
+
+        var layer = '';
+        var _tech = tech;
+
+        if (BemCell.isBemCell(entity)) {
+            entity.layer && (layer = entity.layer);
+            if (typeof tech === 'object') {
+                options = tech;
+            }
+            _tech = entity.tech;
+            entity = entity.entity;
+        }
+
         var naming = bemNaming(options.naming);
 
-        return naming.stringify(entity) + '.' + tech;
+        return path.join(layer, naming.stringify(entity) + '.' + _tech);
     }
 };

--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -1,8 +1,14 @@
 var path = require('path'),
+    assert = require('assert'),
+    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(cell, options) {
+        assert(BemCell.isBemCell(cell),
+            'Provide instance of [@bem/cell](https://github.com/bem-sdk/bem-cell).'
+        )
+
         options || (options = {});
 
         var layer = '';

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -28,6 +28,6 @@ module.exports = {
                 modName ? (naming.modDelim + modName) : '');
 
         return path.join(folder,
-            naming.stringify(entity) + '.' + _tech);
+            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -1,17 +1,33 @@
 var path = require('path'),
+    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(entity, tech, options) {
         options || (options = {});
-        var naming = bemNaming(options.naming),
-            elemFolder = naming.elemDelim + entity.elem,
-            modFolder = naming.modDelim + entity.modName,
-            folder = path.join(entity.block,
-                entity.elem ? elemFolder : '',
-                entity.modName ? modFolder : '');
+
+        var layer = '';
+        var modName = '';
+        var _tech = tech;
+
+        if (BemCell.isBemCell(entity)) {
+            entity.layer && (layer = entity.layer);
+            if (typeof tech === 'object') {
+                options = tech;
+            }
+            _tech = entity.tech;
+            entity = entity.entity;
+            modName = Object(entity.mod).name;
+        } else {
+            modName = entity.modName;
+        }
+
+        var naming = bemNaming(options.naming);
+        var folder = path.join(layer, entity.block,
+                entity.elem ? (naming.elemDelim + entity.elem) : '',
+                modName ? (naming.modDelim + modName) : '');
 
         return path.join(folder,
-            naming.stringify(entity) + '.' + tech);
+            naming.stringify(entity) + '.' + _tech);
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -1,26 +1,16 @@
 var path = require('path'),
-    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
-    path: function(entity, tech, options) {
+    path: function(cell, options) {
         options || (options = {});
 
         var layer = '';
-        var modName = '';
-        var _tech = tech;
+        var tech = cell.tech;
+        var entity = cell.entity;
+        var modName = Object(entity.mod).name;
 
-        if (BemCell.isBemCell(entity)) {
-            entity.layer && (layer = entity.layer);
-            if (typeof tech === 'object') {
-                options = tech;
-            }
-            _tech = entity.tech;
-            entity = entity.entity;
-            modName = Object(entity.mod).name;
-        } else {
-            modName = entity.modName;
-        }
+        cell.layer && (layer = cell.layer);
 
         var naming = bemNaming(options.naming);
         var folder = path.join(layer, entity.block,
@@ -28,6 +18,6 @@ module.exports = {
                 modName ? (naming.modDelim + modName) : '');
 
         return path.join(folder,
-            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
+            naming.stringify(entity) + (tech ? '.' + tech : ''));
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -1,8 +1,14 @@
 var path = require('path'),
+    assert = require('assert'),
+    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(cell, options) {
+        assert(BemCell.isBemCell(cell),
+            'Provide instance of [@bem/cell](https://github.com/bem-sdk/bem-cell).'
+        )
+
         options || (options = {});
 
         var layer = '';

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   },
   "homepage": "https://github.com/bem-sdk/bem-fs-scheme#readme",
   "dependencies": {
+    "@bem/cell": "^0.2.1",
     "bem-naming": "^1.0.1"
   },
   "devDependencies": {
+    "@bem/entity-name": "^1.1.0",
     "chai": "^3.5.0",
     "eslint": "^3.1.1",
     "eslint-config-pedant": "^0.7.0",

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,6 @@ describe('default', function() {
 
     it('should return path + tech', function() {
         expect('a/a.js')
-            .eql(scheme().path({block: 'a'}, 'js'));
-
-        expect('a/a.js')
             .eql(scheme().path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a'}),
@@ -20,15 +17,12 @@ describe('default', function() {
     });
 
     it('should return nested scheme by default', function() {
-        expect(scheme().path({block: 'a', elem: 'e1'}, 'js'))
-            .eql('a/__e1/a__e1.js');
-
         expect(scheme().path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a', elem: 'e1'}),
                     tech: 'js'
                 }))
-        ).eql('a/__e1/a__e1.js', 'bemCell - api');
+        ).eql('a/__e1/a__e1.js');
     });
 
     it('should return error', function() {
@@ -37,15 +31,6 @@ describe('default', function() {
     });
 
     it('should support optional naming style', function() {
-        expect(
-            scheme('nested').path({
-                block: 'a',
-                elem: 'e1',
-                modName: 'mn',
-                modVal: 'mv'
-            }, 'js', {naming: {elem: '%%%', mod: '###'}})
-        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
-
         expect(
             scheme('nested').path(
                 new BemCell({
@@ -57,59 +42,41 @@ describe('default', function() {
                     tech: 'js'
                 }),
                 {naming: {elem: '%%%', mod: '###'}})
-        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
+        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
     });
 
     describe('lib/schemes/nested', function() {
         it('should return path for a block', function() {
-            expect(scheme('nested').path({block: 'a'}, 'js'))
-                .eql('a/a.js');
-
             expect(scheme('nested').path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a'}),
                     tech: 'js'
                 })
-            )).eql('a/a.js', 'bemCell - api');
+            )).eql('a/a.js');
         });
 
         it('should return path for a block with modifier', function() {
             expect(
-                scheme('nested').path({
-                    block: 'a', modName: 'mn', modVal: 'mv'
-                }, 'js')
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({ block: 'a', modName: 'mn', modVal: 'mv' }),
+                        tech: 'js'
+                    })
+                )
             ).eql('a/_mn/a_mn_mv.js');
-
-            expect(
-                scheme('nested').path({
-                    block: 'a', modName: 'mn', modVal: 'mv'
-                }, 'js')
-            ).eql('a/_mn/a_mn_mv.js', 'bemCell - api');
         });
 
         it('should return path for a block with boolean modifier', function() {
-            expect(
-                scheme('nested').path({
-                    block: 'a', modName: 'mn', modVal: true
-                }, 'js')
-            ).eql('a/_mn/a_mn.js');
-
             expect(
                 scheme('nested').path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: true }}),
                     tech: 'js'
                 }))
-            ).eql('a/_mn/a_mn.js', 'bemCell - api');
+            ).eql('a/_mn/a_mn.js');
         });
 
         it('should return path for a block with modifier without value', function() {
-            expect(
-                scheme('nested').path({
-                    block: 'a', modName: 'mn'
-                }, 'js')
-            ).eql('a/_mn/a_mn.js');
-
             expect(
                 scheme('nested').path(
                     new BemCell({
@@ -117,14 +84,10 @@ describe('default', function() {
                         tech: 'js'
                     })
                 )
-            ).eql('a/_mn/a_mn.js', 'bemCell - api');
+            ).eql('a/_mn/a_mn.js');
         });
 
         it('should return path for elem', function() {
-            expect(
-                scheme('nested').path({block: 'a', elem: 'e1'}, 'js')
-            ).eql('a/__e1/a__e1.js');
-
             expect(
                 scheme('nested').path(
                     new BemCell({
@@ -132,19 +95,10 @@ describe('default', function() {
                         tech: 'js'
                     })
                 )
-            ).eql('a/__e1/a__e1.js', 'bemCell - api');
+            ).eql('a/__e1/a__e1.js');
         });
 
         it('should return path for modName elem', function() {
-            expect(
-                scheme('nested').path({
-                    block: 'a',
-                    elem: 'e1',
-                    modName: 'mn',
-                    modVal: 'mv'
-                }, 'js')
-            ).eql('a/__e1/_mn/a__e1_mn_mv.js');
-
             expect(
                 scheme('nested').path(
                     new BemCell({
@@ -156,19 +110,10 @@ describe('default', function() {
                         tech: 'js'
                     })
                 )
-            ).eql('a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
+            ).eql('a/__e1/_mn/a__e1_mn_mv.js');
         });
 
         it('should support optional naming style', function() {
-            expect(
-                scheme('nested').path({
-                    block: 'a',
-                    elem: 'e1',
-                    modName: 'mn',
-                    modVal: 'mv'
-                }, 'js', {naming: {elem: '%%%', mod: '###'}})
-            ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
-
             expect(
                 scheme('nested').path(
                     new BemCell({
@@ -181,7 +126,7 @@ describe('default', function() {
                     }),
                     {naming: {elem: '%%%', mod: '###'}}
                 )
-            ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
+            ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
         });
 
         it('should support optional tech for BemCell', function() {
@@ -195,7 +140,7 @@ describe('default', function() {
                         })
                     })
                 )
-            ).eql('a/__e1/_mn/a__e1_mn_mv', 'bemCell - api');
+            ).eql('a/__e1/_mn/a__e1_mn_mv');
         });
 
         it('should support layer for BemCell', function() {
@@ -211,43 +156,30 @@ describe('default', function() {
                         layer: 'common.blocks'
                     })
                 )
-            ).eql('common.blocks/a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
+            ).eql('common.blocks/a/__e1/_mn/a__e1_mn_mv.js');
         });
     });
 
     describe('lib/schemes/flat', function() {
         it('should return path for a block', function() {
-            expect(scheme('flat').path({block: 'a'}, 'js'))
-                .eql('a.js');
-
             expect(scheme('flat').path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a'}),
                     tech: 'js'
                 })
-            )).eql('a.js', 'bemCell - api');
+            )).eql('a.js');
         });
 
         it('should return path for a block with modifier', function() {
-            expect(
-                scheme('flat').path({
-                    block: 'a', modName: 'mn', modVal: 'mv'
-                }, 'js')
-            ).eql('a_mn_mv.js');
-
             expect(scheme('flat').path(
                 new BemCell({
                     entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: 'mv'}}),
                     tech: 'js'
                 })
-            )).eql('a_mn_mv.js', 'bemCell - api');
+            )).eql('a_mn_mv.js');
         });
 
         it('should return path for elem', function() {
-            expect(
-                scheme('flat').path({block: 'a', elem: 'e1'}, 'js')
-            ).eql('a__e1.js');
-
             expect(
                 scheme('flat').path(
                     new BemCell({
@@ -255,19 +187,10 @@ describe('default', function() {
                         tech: 'js'
                     })
                 )
-            ).eql('a__e1.js', 'bemCell - api');
+            ).eql('a__e1.js');
         });
 
         it('should return path for modName elem', function() {
-            expect(
-                scheme('flat').path({
-                    block: 'a',
-                    elem: 'e1',
-                    modName: 'mn',
-                    modVal: 'mv'
-                }, 'js')
-            ).eql('a__e1_mn_mv.js');
-
             expect(
                 scheme('flat').path(
                     new BemCell({
@@ -279,19 +202,10 @@ describe('default', function() {
                         tech: 'js'
                     })
                 )
-            ).eql('a__e1_mn_mv.js', 'bemCell - api');
+            ).eql('a__e1_mn_mv.js');
         });
 
         it('should support optional naming style', function() {
-            expect(
-                scheme('flat').path({
-                    block: 'a',
-                    elem: 'e1',
-                    modName: 'mn',
-                    modVal: 'mv'
-                }, 'js', {naming: {elem: '%%%', mod: '###'}})
-            ).eql('a%%%e1###mn###mv.js');
-
             expect(
                 scheme('flat').path(
                     new BemCell({
@@ -304,7 +218,7 @@ describe('default', function() {
                     }),
                     {naming: {elem: '%%%', mod: '###'}}
                 )
-            ).eql('a%%%e1###mn###mv.js', 'bemCell - api');
+            ).eql('a%%%e1###mn###mv.js');
         });
 
         it('should support optional tech for BemCell', function() {
@@ -318,7 +232,7 @@ describe('default', function() {
                         })
                     })
                 )
-            ).eql('a__e1_mn_mv', 'bemCell - api');
+            ).eql('a__e1_mn_mv');
         });
 
         it('should support layer for BemCell', function() {
@@ -334,7 +248,7 @@ describe('default', function() {
                         layer: 'common.blocks'
                     })
                 )
-            ).eql('common.blocks/a__e1_mn_mv.js', 'bemCell - api');
+            ).eql('common.blocks/a__e1_mn_mv.js');
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,16 +1,34 @@
 var expect = require('chai').expect,
+    BemCell = require('@bem/cell'),
+    BemEntityName = require('@bem/entity-name'),
     scheme = require('..');
 
 describe('default', function() {
 
     it('should return path + tech', function() {
         expect('a/a.js')
-            .eql(scheme().path({ block: 'a' }, 'js'));
+            .eql(scheme().path({block: 'a'}, 'js'));
+
+        expect('a/a.js')
+            .eql(scheme().path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })),
+                'bemCell - api'
+            );
     });
 
     it('should return nested scheme by default', function() {
-        expect(scheme().path({ block: 'a', elem: 'e1' }, 'js'))
+        expect(scheme().path({block: 'a', elem: 'e1'}, 'js'))
             .eql('a/__e1/a__e1.js');
+
+        expect(scheme().path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                    tech: 'js'
+                }))
+        ).eql('a/__e1/a__e1.js', 'bemCell - api');
     });
 
     it('should return error', function() {
@@ -25,14 +43,34 @@ describe('default', function() {
                 elem: 'e1',
                 modName: 'mn',
                 modVal: 'mv'
-            }, 'js', { naming: { elem: '%%%', mod: '###' }})
+            }, 'js', {naming: {elem: '%%%', mod: '###'}})
         ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
+
+        expect(
+            scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({
+                        block: 'a',
+                        elem: 'e1',
+                        mod: {name: 'mn', val: 'mv'}
+                    }),
+                    tech: 'js'
+                }),
+                {naming: {elem: '%%%', mod: '###'}})
+        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
     });
 
     describe('lib/schemes/nested', function() {
         it('should return path for a block', function() {
-            expect(scheme('nested').path({ block: 'a' }, 'js'))
+            expect(scheme('nested').path({block: 'a'}, 'js'))
                 .eql('a/a.js');
+
+            expect(scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })
+            )).eql('a/a.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier', function() {
@@ -41,6 +79,12 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: 'mv'
                 }, 'js')
             ).eql('a/_mn/a_mn_mv.js');
+
+            expect(
+                scheme('nested').path({
+                    block: 'a', modName: 'mn', modVal: 'mv'
+                }, 'js')
+            ).eql('a/_mn/a_mn_mv.js', 'bemCell - api');
         });
 
         it('should return path for a block with boolean modifier', function() {
@@ -49,6 +93,14 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: true
                 }, 'js')
             ).eql('a/_mn/a_mn.js');
+
+            expect(
+                scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: true }}),
+                    tech: 'js'
+                }))
+            ).eql('a/_mn/a_mn.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier without value', function() {
@@ -57,12 +109,30 @@ describe('default', function() {
                     block: 'a', modName: 'mn'
                 }, 'js')
             ).eql('a/_mn/a_mn.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', mod: {name: 'mn'}}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/_mn/a_mn.js', 'bemCell - api');
         });
 
         it('should return path for elem', function() {
             expect(
-                scheme('nested').path({ block: 'a', elem: 'e1' }, 'js')
+                scheme('nested').path({block: 'a', elem: 'e1'}, 'js')
             ).eql('a/__e1/a__e1.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/__e1/a__e1.js', 'bemCell - api');
         });
 
         it('should return path for modName elem', function() {
@@ -74,6 +144,19 @@ describe('default', function() {
                     modVal: 'mv'
                 }, 'js')
             ).eql('a/__e1/_mn/a__e1_mn_mv.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
         });
 
         it('should support optional naming style', function() {
@@ -83,15 +166,52 @@ describe('default', function() {
                     elem: 'e1',
                     modName: 'mn',
                     modVal: 'mv'
-                }, 'js', { naming: { elem: '%%%', mod: '###' }})
+                }, 'js', {naming: {elem: '%%%', mod: '###'}})
             ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    }),
+                    {naming: {elem: '%%%', mod: '###'}}
+                )
+            ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support layer for BemCell', function() {
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js',
+                        layer: 'common.blocks'
+                    })
+                )
+            ).eql('common.blocks/a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
         });
     });
 
     describe('lib/schemes/flat', function() {
         it('should return path for a block', function() {
-            expect(scheme('flat').path({ block: 'a' }, 'js'))
+            expect(scheme('flat').path({block: 'a'}, 'js'))
                 .eql('a.js');
+
+            expect(scheme('flat').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })
+            )).eql('a.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier', function() {
@@ -100,12 +220,28 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: 'mv'
                 }, 'js')
             ).eql('a_mn_mv.js');
+
+            expect(scheme('flat').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: 'mv'}}),
+                    tech: 'js'
+                })
+            )).eql('a_mn_mv.js', 'bemCell - api');
         });
 
         it('should return path for elem', function() {
             expect(
-                scheme('flat').path({ block: 'a', elem: 'e1' }, 'js')
+                scheme('flat').path({block: 'a', elem: 'e1'}, 'js')
             ).eql('a__e1.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a__e1.js', 'bemCell - api');
         });
 
         it('should return path for modName elem', function() {
@@ -117,6 +253,19 @@ describe('default', function() {
                     modVal: 'mv'
                 }, 'js')
             ).eql('a__e1_mn_mv.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a__e1_mn_mv.js', 'bemCell - api');
         });
 
         it('should support optional naming style', function() {
@@ -126,8 +275,38 @@ describe('default', function() {
                     elem: 'e1',
                     modName: 'mn',
                     modVal: 'mv'
-                }, 'js', { naming: { elem: '%%%', mod: '###' }})
+                }, 'js', {naming: {elem: '%%%', mod: '###'}})
             ).eql('a%%%e1###mn###mv.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    }),
+                    {naming: {elem: '%%%', mod: '###'}}
+                )
+            ).eql('a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support layer for BemCell', function() {
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js',
+                        layer: 'common.blocks'
+                    })
+                )
+            ).eql('common.blocks/a__e1_mn_mv.js', 'bemCell - api');
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -184,6 +184,20 @@ describe('default', function() {
             ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
         });
 
+        it('should support optional tech for BemCell', function() {
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        })
+                    })
+                )
+            ).eql('a/__e1/_mn/a__e1_mn_mv', 'bemCell - api');
+        });
+
         it('should support layer for BemCell', function() {
             expect(
                 scheme('nested').path(
@@ -291,6 +305,20 @@ describe('default', function() {
                     {naming: {elem: '%%%', mod: '###'}}
                 )
             ).eql('a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support optional tech for BemCell', function() {
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        })
+                    })
+                )
+            ).eql('a__e1_mn_mv', 'bemCell - api');
         });
 
         it('should support layer for BemCell', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,12 @@ describe('default', function() {
             )).eql('a/a.js');
         });
 
+        it('should throw when you use not BemCell', function() {
+            expect(
+                scheme('nested').path.bind(null, new BemEntityName({block: 'a'}))
+            ).to.throw(/@bem\/cell/);
+        });
+
         it('should return path for a block with modifier', function() {
             expect(
                 scheme('nested').path(
@@ -168,6 +174,12 @@ describe('default', function() {
                     tech: 'js'
                 })
             )).eql('a.js');
+        });
+
+        it('should throw when you use not BemCell', function() {
+            expect(
+                scheme('flat').path.bind(null, new BemEntityName({block: 'a'}))
+            ).to.throw(/@bem\/cell/);
         });
 
         it('should return path for a block with modifier', function() {


### PR DESCRIPTION
closing #10 
Example of new API: 
```js
var scheme = require('bem-fs-scheme');
scheme().path(
    new BemCell({
        entity: new BemEntityName({
            block: 'a',
            elem: 'e1',
            mod: {name: 'mn', val: 'mv'}
        }),
        tech: 'js',
        layer: 'common.blocks'
    })
)
// "common.blocks/a/__e1/_mn/a__e1_mn_mv.js"
```

options for `bem-naming` could be passed as second argument:
```js
var scheme = require('bem-fs-scheme');
scheme().path(bemCell, {naming: {elem: '%%%', mod: '###'}})
```