### PR TITLE
Support bem-react-core magic fs naming

### DIFF
--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -20,6 +20,7 @@ module.exports = {
 
         var naming = bemNaming(options.naming);
 
-        return path.join(layer, naming.stringify(entity) + '.' + _tech);
+        return path.join(layer,
+            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
     }
 };

--- a/lib/schemes/flat.js
+++ b/lib/schemes/flat.js
@@ -1,10 +1,25 @@
-var bemNaming = require('bem-naming');
+var path = require('path'),
+    BemCell = require('@bem/cell'),
+    bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(entity, tech, options) {
         options || (options = {});
+
+        var layer = '';
+        var _tech = tech;
+
+        if (BemCell.isBemCell(entity)) {
+            entity.layer && (layer = entity.layer);
+            if (typeof tech === 'object') {
+                options = tech;
+            }
+            _tech = entity.tech;
+            entity = entity.entity;
+        }
+
         var naming = bemNaming(options.naming);
 
-        return naming.stringify(entity) + '.' + tech;
+        return path.join(layer, naming.stringify(entity) + '.' + _tech);
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -28,6 +28,6 @@ module.exports = {
                 modName ? (naming.modDelim + modName) : '');
 
         return path.join(folder,
-            naming.stringify(entity) + '.' + _tech);
+            naming.stringify(entity) + (_tech ? '.' + _tech : ''));
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -1,17 +1,33 @@
 var path = require('path'),
+    BemCell = require('@bem/cell'),
     bemNaming = require('bem-naming');
 
 module.exports = {
     path: function(entity, tech, options) {
         options || (options = {});
-        var naming = bemNaming(options.naming),
-            elemFolder = naming.elemDelim + entity.elem,
-            modFolder = naming.modDelim + entity.modName,
-            folder = path.join(entity.block,
-                entity.elem ? elemFolder : '',
-                entity.modName ? modFolder : '');
+
+        var layer = '';
+        var modName = '';
+        var _tech = tech;
+
+        if (BemCell.isBemCell(entity)) {
+            entity.layer && (layer = entity.layer);
+            if (typeof tech === 'object') {
+                options = tech;
+            }
+            _tech = entity.tech;
+            entity = entity.entity;
+            modName = Object(entity.mod).name;
+        } else {
+            modName = entity.modName;
+        }
+
+        var naming = bemNaming(options.naming);
+        var folder = path.join(layer, entity.block,
+                entity.elem ? (naming.elemDelim + entity.elem) : '',
+                modName ? (naming.modDelim + modName) : '');
 
         return path.join(folder,
-            naming.stringify(entity) + '.' + tech);
+            naming.stringify(entity) + '.' + _tech);
     }
 };

--- a/lib/schemes/nested.js
+++ b/lib/schemes/nested.js
@@ -23,9 +23,12 @@ module.exports = {
         }
 
         var naming = bemNaming(options.naming);
+        var elemDelim = typeof options.elemDirDelim === 'string' ? options.elemDirDelim : naming.elemDelim;
+        var modDelim = typeof options.modDirDelim === 'string' ? options.modDirDelim : naming.modDelim;
+
         var folder = path.join(layer, entity.block,
-                entity.elem ? (naming.elemDelim + entity.elem) : '',
-                modName ? (naming.modDelim + modName) : '');
+                entity.elem ? (elemDelim + entity.elem) : '',
+                modName ? (modDelim + modName) : '');
 
         return path.join(folder,
             naming.stringify(entity) + (_tech ? '.' + _tech : ''));

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   },
   "homepage": "https://github.com/bem-sdk/bem-fs-scheme#readme",
   "dependencies": {
+    "@bem/cell": "^0.2.1",
     "bem-naming": "^1.0.1"
   },
   "devDependencies": {
+    "@bem/entity-name": "^1.1.0",
     "chai": "^3.5.0",
     "eslint": "^3.1.1",
     "eslint-config-pedant": "^0.7.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,16 +1,34 @@
 var expect = require('chai').expect,
+    BemCell = require('@bem/cell'),
+    BemEntityName = require('@bem/entity-name'),
     scheme = require('..');
 
 describe('default', function() {
 
     it('should return path + tech', function() {
         expect('a/a.js')
-            .eql(scheme().path({ block: 'a' }, 'js'));
+            .eql(scheme().path({block: 'a'}, 'js'));
+
+        expect('a/a.js')
+            .eql(scheme().path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })),
+                'bemCell - api'
+            );
     });
 
     it('should return nested scheme by default', function() {
-        expect(scheme().path({ block: 'a', elem: 'e1' }, 'js'))
+        expect(scheme().path({block: 'a', elem: 'e1'}, 'js'))
             .eql('a/__e1/a__e1.js');
+
+        expect(scheme().path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                    tech: 'js'
+                }))
+        ).eql('a/__e1/a__e1.js', 'bemCell - api');
     });
 
     it('should return error', function() {
@@ -25,14 +43,34 @@ describe('default', function() {
                 elem: 'e1',
                 modName: 'mn',
                 modVal: 'mv'
-            }, 'js', { naming: { elem: '%%%', mod: '###' }})
+            }, 'js', {naming: {elem: '%%%', mod: '###'}})
         ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
+
+        expect(
+            scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({
+                        block: 'a',
+                        elem: 'e1',
+                        mod: {name: 'mn', val: 'mv'}
+                    }),
+                    tech: 'js'
+                }),
+                {naming: {elem: '%%%', mod: '###'}})
+        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
     });
 
     describe('lib/schemes/nested', function() {
         it('should return path for a block', function() {
-            expect(scheme('nested').path({ block: 'a' }, 'js'))
+            expect(scheme('nested').path({block: 'a'}, 'js'))
                 .eql('a/a.js');
+
+            expect(scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })
+            )).eql('a/a.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier', function() {
@@ -41,6 +79,12 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: 'mv'
                 }, 'js')
             ).eql('a/_mn/a_mn_mv.js');
+
+            expect(
+                scheme('nested').path({
+                    block: 'a', modName: 'mn', modVal: 'mv'
+                }, 'js')
+            ).eql('a/_mn/a_mn_mv.js', 'bemCell - api');
         });
 
         it('should return path for a block with boolean modifier', function() {
@@ -49,6 +93,14 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: true
                 }, 'js')
             ).eql('a/_mn/a_mn.js');
+
+            expect(
+                scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: true }}),
+                    tech: 'js'
+                }))
+            ).eql('a/_mn/a_mn.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier without value', function() {
@@ -57,12 +109,30 @@ describe('default', function() {
                     block: 'a', modName: 'mn'
                 }, 'js')
             ).eql('a/_mn/a_mn.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', mod: {name: 'mn'}}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/_mn/a_mn.js', 'bemCell - api');
         });
 
         it('should return path for elem', function() {
             expect(
-                scheme('nested').path({ block: 'a', elem: 'e1' }, 'js')
+                scheme('nested').path({block: 'a', elem: 'e1'}, 'js')
             ).eql('a/__e1/a__e1.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/__e1/a__e1.js', 'bemCell - api');
         });
 
         it('should return path for modName elem', function() {
@@ -74,6 +144,19 @@ describe('default', function() {
                     modVal: 'mv'
                 }, 'js')
             ).eql('a/__e1/_mn/a__e1_mn_mv.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
         });
 
         it('should support optional naming style', function() {
@@ -83,15 +166,52 @@ describe('default', function() {
                     elem: 'e1',
                     modName: 'mn',
                     modVal: 'mv'
-                }, 'js', { naming: { elem: '%%%', mod: '###' }})
+                }, 'js', {naming: {elem: '%%%', mod: '###'}})
             ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
+
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    }),
+                    {naming: {elem: '%%%', mod: '###'}}
+                )
+            ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support layer for BemCell', function() {
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js',
+                        layer: 'common.blocks'
+                    })
+                )
+            ).eql('common.blocks/a/__e1/_mn/a__e1_mn_mv.js', 'bemCell - api');
         });
     });
 
     describe('lib/schemes/flat', function() {
         it('should return path for a block', function() {
-            expect(scheme('flat').path({ block: 'a' }, 'js'))
+            expect(scheme('flat').path({block: 'a'}, 'js'))
                 .eql('a.js');
+
+            expect(scheme('flat').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a'}),
+                    tech: 'js'
+                })
+            )).eql('a.js', 'bemCell - api');
         });
 
         it('should return path for a block with modifier', function() {
@@ -100,12 +220,28 @@ describe('default', function() {
                     block: 'a', modName: 'mn', modVal: 'mv'
                 }, 'js')
             ).eql('a_mn_mv.js');
+
+            expect(scheme('flat').path(
+                new BemCell({
+                    entity: new BemEntityName({block: 'a', mod: {name: 'mn', val: 'mv'}}),
+                    tech: 'js'
+                })
+            )).eql('a_mn_mv.js', 'bemCell - api');
         });
 
         it('should return path for elem', function() {
             expect(
-                scheme('flat').path({ block: 'a', elem: 'e1' }, 'js')
+                scheme('flat').path({block: 'a', elem: 'e1'}, 'js')
             ).eql('a__e1.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({block: 'a', elem: 'e1'}),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a__e1.js', 'bemCell - api');
         });
 
         it('should return path for modName elem', function() {
@@ -117,6 +253,19 @@ describe('default', function() {
                     modVal: 'mv'
                 }, 'js')
             ).eql('a__e1_mn_mv.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    })
+                )
+            ).eql('a__e1_mn_mv.js', 'bemCell - api');
         });
 
         it('should support optional naming style', function() {
@@ -126,8 +275,38 @@ describe('default', function() {
                     elem: 'e1',
                     modName: 'mn',
                     modVal: 'mv'
-                }, 'js', { naming: { elem: '%%%', mod: '###' }})
+                }, 'js', {naming: {elem: '%%%', mod: '###'}})
             ).eql('a%%%e1###mn###mv.js');
+
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js'
+                    }),
+                    {naming: {elem: '%%%', mod: '###'}}
+                )
+            ).eql('a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support layer for BemCell', function() {
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        }),
+                        tech: 'js',
+                        layer: 'common.blocks'
+                    })
+                )
+            ).eql('common.blocks/a__e1_mn_mv.js', 'bemCell - api');
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -184,6 +184,20 @@ describe('default', function() {
             ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
         });
 
+        it('should support optional tech for BemCell', function() {
+            expect(
+                scheme('nested').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        })
+                    })
+                )
+            ).eql('a/__e1/_mn/a__e1_mn_mv', 'bemCell - api');
+        });
+
         it('should support layer for BemCell', function() {
             expect(
                 scheme('nested').path(
@@ -291,6 +305,20 @@ describe('default', function() {
                     {naming: {elem: '%%%', mod: '###'}}
                 )
             ).eql('a%%%e1###mn###mv.js', 'bemCell - api');
+        });
+
+        it('should support optional tech for BemCell', function() {
+            expect(
+                scheme('flat').path(
+                    new BemCell({
+                        entity: new BemEntityName({
+                            block: 'a',
+                            elem: 'e1',
+                            mod: {name: 'mn', val: 'mv'}
+                        })
+                    })
+                )
+            ).eql('a__e1_mn_mv', 'bemCell - api');
         });
 
         it('should support layer for BemCell', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,51 @@ describe('default', function() {
         ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js', 'bemCell - api');
     });
 
+    it('should support optional naming style with different delim for elem/mod dirs', function() {
+        expect(
+            scheme('nested').path({
+                block: 'a',
+                elem: 'e1',
+                modName: 'mn',
+                modVal: 'mv'
+            }, 'js', {naming: {elem: '%%%', mod: '###'}})
+        ).eql('a/%%%e1/###mn/a%%%e1###mn###mv.js');
+
+        expect(
+            scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({
+                        block: 'a',
+                        elem: 'e1',
+                        mod: {name: 'mn', val: 'mv'}
+                    }),
+                    tech: 'js'
+                }),
+                {
+                    naming: {elem: '%%%', mod: '###'},
+                    elemDirDelim: '*',
+                    modDirDelim: '^'
+                })
+        ).eql('a/*e1/^mn/a%%%e1###mn###mv.js', 'bemCell - api');
+
+        expect(
+            scheme('nested').path(
+                new BemCell({
+                    entity: new BemEntityName({
+                        block: 'a',
+                        elem: 'e1',
+                        mod: {name: 'mn', val: 'mv'}
+                    }),
+                    tech: 'js'
+                }),
+                {
+                    naming: {elem: '%%%', mod: '###'},
+                    elemDirDelim: '',
+                    modDirDelim: ''
+                })
+        ).eql('a/e1/mn/a%%%e1###mn###mv.js', 'bemCell - api empty string');
+    });
+
     describe('lib/schemes/nested', function() {
         it('should return path for a block', function() {
             expect(scheme('nested').path({block: 'a'}, 'js'))


### PR DESCRIPTION
because we can:
https://github.com/bem/bem-react-components/tree/8f9ef86e8d8ce865359bb9d6a6549a13cc7e0261/blocks/Button/Text

elem has delimetr in name but not in directory name:
 `blocks/Button/Text/Button-Text.js`